### PR TITLE
fix(shelly): update EM response format for Marstek API v1.0 compliance

### DIFF
--- a/shelly/shelly.py
+++ b/shelly/shelly.py
@@ -45,22 +45,23 @@ class Shelly:
         b = self._calculate_derived_values(powers[1])
         c = self._calculate_derived_values(powers[2])
 
-        total_act_power = round(sum(powers), 3)
-        total_act_power = total_act_power + (
+        total_power = round(sum(powers), 3)
+        total_power = total_power + (
             0.001
-            if total_act_power == round(total_act_power) or total_act_power == 0
+            if total_power == round(total_power) or total_power == 0
             else 0
         )
 
         return {
             "id": request_id,
             "src": self._device_id,
-            "dst": "unknown",
             "result": {
-                "a_act_power": a,
-                "b_act_power": b,
-                "c_act_power": c,
-                "total_act_power": total_act_power,
+                "id": 0,
+                "ct_state": 1,
+                "a_power": a,
+                "b_power": b,
+                "c_power": c,
+                "total_power": total_power,
             },
         }
 

--- a/shelly/shelly_udp_test.py
+++ b/shelly/shelly_udp_test.py
@@ -40,7 +40,17 @@ class TestShellyUDP(unittest.TestCase):
                 }
                 client.sendto(json.dumps(req).encode(), ("127.0.0.1", port))
                 data, _ = client.recvfrom(1024)
-                responses.append(json.loads(data.decode())["id"])
+                response = json.loads(data.decode())
+                responses.append(response["id"])
+                
+                # Verify API compliance with Marstek Rev 1.0
+                result = response["result"]
+                self.assertIn("id", result)
+                self.assertIn("ct_state", result) 
+                self.assertIn("a_power", result)
+                self.assertIn("b_power", result)
+                self.assertIn("c_power", result)
+                self.assertIn("total_power", result)
 
             threads = []
             start = time.time()
@@ -56,6 +66,51 @@ class TestShellyUDP(unittest.TestCase):
         finally:
             client.close()
             # send dummy packet to unblock server if waiting on recv
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                s.sendto(b"{}", ("127.0.0.1", port))
+            shelly.stop()
+
+    def test_em_response_format_compliance(self):
+        """Test that EM.GetStatus response matches Marstek API Rev 1.0 specification"""
+        pm = DummyPowermeter()
+        cf = ClientFilter([IPv4Network("127.0.0.1/32")])
+
+        tmp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        tmp.bind(("", 0))
+        port = tmp.getsockname()[1]
+        tmp.close()
+
+        shelly = Shelly([(pm, cf)], udp_port=port, device_id="test-device")
+        shelly.start()
+        try:
+            client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            
+            request = {
+                "id": 1,
+                "method": "EM.GetStatus",
+                "params": {"id": 0}
+            }
+            
+            client.sendto(json.dumps(request).encode(), ("127.0.0.1", port))
+            data, _ = client.recvfrom(1024)
+            response = json.loads(data.decode())
+            
+            # Verify top-level response format
+            self.assertEqual(response["id"], 1)
+            self.assertEqual(response["src"], "test-device")
+            self.assertNotIn("dst", response)  # Should not contain dst field
+            
+            # Verify result format matches API spec
+            result = response["result"]
+            self.assertEqual(result["id"], 0)
+            self.assertEqual(result["ct_state"], 1)
+            self.assertIsInstance(result["a_power"], (int, float))
+            self.assertIsInstance(result["b_power"], (int, float))  
+            self.assertIsInstance(result["c_power"], (int, float))
+            self.assertIsInstance(result["total_power"], (int, float))
+            
+        finally:
+            client.close()
             with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
                 s.sendto(b"{}", ("127.0.0.1", port))
             shelly.stop()

--- a/shelly/shelly_udp_test.py
+++ b/shelly/shelly_udp_test.py
@@ -42,11 +42,11 @@ class TestShellyUDP(unittest.TestCase):
                 data, _ = client.recvfrom(1024)
                 response = json.loads(data.decode())
                 responses.append(response["id"])
-                
+
                 # Verify API compliance with Marstek Rev 1.0
                 result = response["result"]
                 self.assertIn("id", result)
-                self.assertIn("ct_state", result) 
+                self.assertIn("ct_state", result)
                 self.assertIn("a_power", result)
                 self.assertIn("b_power", result)
                 self.assertIn("c_power", result)
@@ -84,31 +84,27 @@ class TestShellyUDP(unittest.TestCase):
         shelly.start()
         try:
             client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            
-            request = {
-                "id": 1,
-                "method": "EM.GetStatus",
-                "params": {"id": 0}
-            }
-            
+
+            request = {"id": 1, "method": "EM.GetStatus", "params": {"id": 0}}
+
             client.sendto(json.dumps(request).encode(), ("127.0.0.1", port))
             data, _ = client.recvfrom(1024)
             response = json.loads(data.decode())
-            
+
             # Verify top-level response format
             self.assertEqual(response["id"], 1)
             self.assertEqual(response["src"], "test-device")
             self.assertNotIn("dst", response)  # Should not contain dst field
-            
+
             # Verify result format matches API spec
             result = response["result"]
             self.assertEqual(result["id"], 0)
             self.assertEqual(result["ct_state"], 1)
             self.assertIsInstance(result["a_power"], (int, float))
-            self.assertIsInstance(result["b_power"], (int, float))  
+            self.assertIsInstance(result["b_power"], (int, float))
             self.assertIsInstance(result["c_power"], (int, float))
             self.assertIsInstance(result["total_power"], (int, float))
-            
+
         finally:
             client.close()
             with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:


### PR DESCRIPTION
  - Change field names: *_act_power → *_power
  - Add required ct_state and id fields in result
  - Remove unnecessary dst field
  - Align with official Marstek Device Open API Rev 1.0 specification